### PR TITLE
refactor: directly use readable-stream

### DIFF
--- a/.changeset/three-humans-laugh.md
+++ b/.changeset/three-humans-laugh.md
@@ -1,0 +1,5 @@
+---
+'@rdfjs-elements/rdf-editor': patch
+---
+
+Replace into-stream dependency with readable-stream

--- a/packages/rdf-editor/package.json
+++ b/packages/rdf-editor/package.json
@@ -25,7 +25,7 @@
     "@rdf-esm/formats-common": "^0.5.3",
     "@vanillawc/wc-codemirror": "^1.8.10",
     "codemirror": "^5.56.0",
-    "into-stream": "^5.1.1",
+    "readable-stream": "^3",
     "lit-element": "^2.2.1",
     "lit-html": "^1.1.2",
     "string-to-stream": "^3.0.1"

--- a/packages/testing-helpers/index.js
+++ b/packages/testing-helpers/index.js
@@ -15,6 +15,11 @@ module.exports = function factory() {
         body: `export { default } from '@rdfjs-elements/testing/into-stream/index.js';`,
       }
     }
+    if (context.url.match(/node_modules\/readable-stream\/readable.js$/)) {
+      return {
+        body: `export { Readable } from '@rdfjs-elements/testing/stream/index.js';`,
+      }
+    }
     return context
   }
 }

--- a/packages/testing-helpers/into-stream/index.js
+++ b/packages/testing-helpers/into-stream/index.js
@@ -1,3 +1,3 @@
-export default {
-  object() {},
-}
+export default function intoStream() {}
+
+intoStream.object = () => {}

--- a/packages/testing-helpers/stream/index.js
+++ b/packages/testing-helpers/stream/index.js
@@ -1,0 +1,1 @@
+export class Readable {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4918,7 +4918,7 @@ fresh@0.5.2, fresh@~0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
-from2@^2.1.0, from2@^2.3.0:
+from2@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
   integrity sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=
@@ -5661,14 +5661,6 @@ intersection-observer@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.7.0.tgz#ee16bee978db53516ead2f0a8154b09b400bbdc9"
   integrity sha512-Id0Fij0HsB/vKWGeBe9PxeY45ttRiBmhFyyt/geBdDHBYNctMRTE3dC1U3ujzz3lap+hVXlEcVaB56kZP/eEUg==
-
-into-stream@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-5.1.1.tgz#f9a20a348a11f3c13face22763f2d02e127f4db8"
-  integrity sha512-krrAJ7McQxGGmvaYbB7Q1mcA+cRwg9Ij2RfWIeVesNBgVDZmzY/Fa4IpZUT3bmdRzMzdf/mzltCG2Dq99IZGBA==
-  dependencies:
-    from2 "^2.3.0"
-    p-is-promise "^3.0.0"
 
 invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
@@ -7545,11 +7537,6 @@ p-finally@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
-p-is-promise@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-3.0.0.tgz#58e78c7dfe2e163cf2a04ff869e7c1dba64a5971"
-  integrity sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==
-
 p-limit@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
@@ -8266,7 +8253,7 @@ read-yaml-file@^1.1.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@3.6.0, readable-stream@^3.0.2, readable-stream@^3.0.6, readable-stream@^3.4.0, readable-stream@^3.6.0:
+readable-stream@3.6.0, readable-stream@^3, readable-stream@^3.0.2, readable-stream@^3.0.6, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==


### PR DESCRIPTION
This should prevent duplicate version of `readable-stream` (more specifically mixing v2 with v3), which would break on stream operations