### PR TITLE
fix(editor): ensure wait before serialising

### DIFF
--- a/.changeset/swift-bags-exist.md
+++ b/.changeset/swift-bags-exist.md
@@ -1,0 +1,5 @@
+---
+"@rdfjs-elements/rdf-editor": patch
+---
+
+wait for `<code-mirror>` to be ready before serialising `.quads`

--- a/packages/rdf-editor/src/RdfEditor.js
+++ b/packages/rdf-editor/src/RdfEditor.js
@@ -159,6 +159,8 @@ export class RdfEditor extends Editor {
 
   async __serialize() {
     if (!this.format) return
+    
+    await this.ready
 
     const formats = await import('@rdfjs-elements/formats-pretty')
     const { Readable } = await import('./stream')

--- a/packages/rdf-editor/src/RdfEditor.js
+++ b/packages/rdf-editor/src/RdfEditor.js
@@ -159,7 +159,7 @@ export class RdfEditor extends Editor {
 
   async __serialize() {
     if (!this.format) return
-    
+
     await this.ready
 
     const formats = await import('@rdfjs-elements/formats-pretty')


### PR DESCRIPTION
In cases when the editor is rendered and very quickly set the `quads` property, it may happen that the serialising starts before code mirror is ready and the serialised output get lost somehow

This fixes this problem by waiting for `this.ready` to resolved before starting to parse