### PR TITLE
fix: error thrown when element gets detached

### DIFF
--- a/.changeset/polite-garlics-explain.md
+++ b/.changeset/polite-garlics-explain.md
@@ -1,0 +1,5 @@
+---
+"@rdfjs-elements/editor-base": patch
+---
+
+fix: error thrown when element gets detached

--- a/packages/editor-base/index.js
+++ b/packages/editor-base/index.js
@@ -221,6 +221,10 @@ export default class Editor extends LitElement {
   }
 
   __setParseHandler() {
+    if (!this.codeMirror.editor) {
+      return
+    }
+
     if (this[ParseHandler]) {
       this.codeMirror.editor.off('blur', this[ParseHandler])
       this.codeMirror.editor.off('change', this[ParseHandler])


### PR DESCRIPTION
Fixes a problem which can occur when element gets detached but still tries to hook up parse handler on code mirror