### PR TITLE
fix(formats): escape long multiline literals in Turtle/TriG serializer

### DIFF
--- a/packages/formats/serializers/graphy/coercions.js
+++ b/packages/formats/serializers/graphy/coercions.js
@@ -7,12 +7,19 @@ export class LongLiteral {
   }
 
   toTerm() {
-    const raw = `"""${this.term.value.replace(/"$/, '\\"')}"""`
+    const raw = `"""${LongLiteral.escapeValue(this.term.value)}"""`
 
     return {
       terse: prefixes => raw + this.langOrDatatype(prefixes),
       verbose: prefixes => raw + this.langOrDatatype(prefixes),
     }
+  }
+
+  static escapeValue(value) {
+    return value
+      .replace(/\\/g, '\\\\')
+      .replace(/"""/g, '""\\"')
+      .replace(/"{1,2}$/, match => `${match.slice(0, -1)}\\"`)
   }
 
   langOrDatatype(prefixes) {

--- a/packages/formats/test/serializers/index.test.js
+++ b/packages/formats/test/serializers/index.test.js
@@ -8,8 +8,10 @@ import getStream from 'get-stream'
 import { fromFile } from '@zazuko/rdf-utils-fs'
 import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
+import { Readable } from 'stream'
 import JsonldSerializer from '../../serializers/jsonld.js'
-import { TurtleSerializer } from '../../serializers/graphy.js'
+import formats from '../../index.js'
+import { TurtleSerializer, TrigSerializer } from '../../serializers/graphy.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -132,6 +134,33 @@ describe('@rdfjs-elements/formats-pretty/serializers', () => {
       // then
       expect(serialized).toMatchSnapshot()
     })
+
+    for (const [label, Serializer, mime] of [
+      ['turtle', TurtleSerializer, 'text/turtle'],
+      ['trig', TrigSerializer, 'application/trig'],
+    ]) {
+      it(`serializes parseable multiline literals with backslash before newline in ${label}`, async () => {
+        // given
+        const dataset = $rdf.dataset([
+          $rdf.quad(
+            $rdf.namedNode('http://example/s'),
+            $rdf.namedNode('http://example/p'),
+            $rdf.literal(`hello \\
+world`)
+          ),
+        ])
+        const sink = new Serializer()
+
+        // when
+        const serialized = await getStream(sink.import(dataset.toStream()))
+        const parsed = await $rdf
+          .dataset()
+          .import(formats.parsers.import(mime, Readable.from([serialized])))
+
+        // then
+        expect(parsed.toCanonical()).to.eq(dataset.toCanonical())
+      })
+    }
   })
 
   describe('jsonld', () => {


### PR DESCRIPTION
Hi!

This fixes a serialization bug in @rdfjs-elements/formats-pretty where multiline literals containing a backslash immediately before a newline were emitted as invalid Turtle/TriG. The pretty serializer now escapes long literals safely while preserving the existing multiline output style.